### PR TITLE
Add clientIP as option instead of host to match via traefik

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: generic-service
 description: A Helm chart for Kubernetes
-version: 1.0.88
+version: 1.0.89
 dependencies:
   - name: memcached
     version: 6.6.x

--- a/charts/generic-service/templates/ingressroute.yaml
+++ b/charts/generic-service/templates/ingressroute.yaml
@@ -9,7 +9,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    {{- if $value.clientIP }} # Match to clientIP instead of host
+    {{- if $value.clientIP | quote }} # Match to clientIP instead of host
     - match: ClientIP(`{{ $value.clientIP }}`)
     {{- else if contains "*." $value.host }}
     - match: HostRegexp(`{subdomain:[a-z0-9]+}.{{ $value.host | replace "*." "" }}`)

--- a/charts/generic-service/templates/ingressroute.yaml
+++ b/charts/generic-service/templates/ingressroute.yaml
@@ -9,7 +9,9 @@ spec:
   entryPoints:
     - websecure
   routes:
-    {{- if contains "*." $value.host }}
+    {{- if $value.clientIP }} # Match to clientIP instead of host
+    - match: ClientIP(`{{ $value.clientIP }}`)
+    {{- else if contains "*." $value.host }}
     - match: HostRegexp(`{subdomain:[a-z0-9]+}.{{ $value.host | replace "*." "" }}`)
     {{- else }}
     - match: Host(`{{ $value.host }}`)


### PR DESCRIPTION
Unrefined PR to add the ability to use `ClientIP` instead of `Host` or `HostRegexp` to match via Traefik.