### PR TITLE
Update container names

### DIFF
--- a/charts/generic-service/templates/frontend-deployment.yaml
+++ b/charts/generic-service/templates/frontend-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         tags.datadoghq.com/version: {{ $.Values.version | quote }}
     spec:
       containers:
-        - name: {{ $.Chart.Name }}
+        - name: {{ $value.name }}
           image: "{{ $value.image }}"
           imagePullPolicy: {{ $value.pullPolicy }}
           env:

--- a/charts/generic-service/templates/worker-deployment.yaml
+++ b/charts/generic-service/templates/worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         tags.datadoghq.com/version: {{ $.Values.version | quote }}
     spec:
       containers:
-        - name: {{ $.Chart.Name }}
+        - name: {{ $value.name }}
           image: "{{ $value.image }}"
           imagePullPolicy: {{ $value.pullPolicy }}
           env:


### PR DESCRIPTION
Currently all frontend and worker container names are "generic-service". I think we should change them to match the pod name, especially since we're doing one container per pod. This will add more descriptive names when looking at containers across namespaces and even within a namespace.