### PR TITLE
[DEVOPS-1478, DEVOPS-1186] Add support for migrations job and initContainers

### DIFF
--- a/charts/generic-service/templates/frontend-deployment.yaml
+++ b/charts/generic-service/templates/frontend-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             {{- end }}
       {{- if eq $value.initContainer.enabled true }}
       initContainers:
-        name: {{ $value.initContainer.name }}
+        name: {{ $value.initContainer.name }}-init
         image: {{ $value.initContainer.image }}
         command: {{ $value.initContainer.command  }}
       {{- end }}

--- a/charts/generic-service/templates/frontend-deployment.yaml
+++ b/charts/generic-service/templates/frontend-deployment.yaml
@@ -77,6 +77,12 @@ spec:
             - name: {{ $value.name }}
               mountPath: {{ $value.mountPath }}
             {{- end }}
+      {{- if eq $value.initContainer.enabled true }}
+      initContainers:
+        name: {{ $value.initContainer.name }}
+        image: {{ $value.initContainer.image }}
+        command: {{ $value.initContainer.command  }}
+      {{- end }}
       volumes:
         {{- range $key, $value := $.Values.keyinjection }}
         - name: {{ $value.name }}

--- a/charts/generic-service/templates/migrations-job.yaml
+++ b/charts/generic-service/templates/migrations-job.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     spec:
       containers:
-      - name: {{ $value.name  }}
+      - name: {{ $value.name }}-job
         command: {{ $value.command  }}
         image: "{{ $value.image  }}"
         restartPolicy: {{ $value.restartPolicy  }}

--- a/charts/generic-service/templates/migrations-job.yaml
+++ b/charts/generic-service/templates/migrations-job.yaml
@@ -1,0 +1,20 @@
+{{- range $key, $value := .Values.migrations }}
+{{- if eq $value.enabled true }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: {{ $.Release.Namespace }}-migrations-job-
+  namespace: {{ $.Release.Namespace }}
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 4
+  template:
+    spec:
+      containers:
+      - name: {{ $value.name  }}
+        command: {{ $value.command  }}
+        image: "{{ $value.image  }}"
+        restartPolicy: {{ $value.restartPolicy  }}
+        envFrom: {{- toYaml $value.envFrom | nindent 12 }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
More detail in the linked story, but this PR is meant to add support for a migrations job and initContainers (to watch those job). Required to implement [this PR in devops-cicd](https://github.com/tithely/devops-cicd/pull/33/files).
- Using `generateName: {{ $.Release.Namespace }}-migrations-job-` to get Kubernetes to spin up a unique name each job.

If you have questions, feel free to ask away.