### PR TITLE
HOTFIX -- Conditionalize templates for LB vs Traefik

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: generic-service
 description: A Helm chart for Kubernetes
-version: 1.0.98
+version: 1.0.99
 dependencies:
   - name: memcached
     version: 6.6.x

--- a/charts/generic-service/templates/ingressroute.yaml
+++ b/charts/generic-service/templates/ingressroute.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $value := .Values.frontend }}
-{{- if not $value.loadBalancer.enabled }}
+{{- if or (empty $value.loadBalancer) (not $value.loadBalancer.enabled) }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute

--- a/charts/generic-service/templates/service-lb.yaml
+++ b/charts/generic-service/templates/service-lb.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $value := .Values.frontend }}
-{{- if eq $value.loadBalancer.enabled true }}
+{{- if and $value.loadBalancer $value.loadBalancer.enabled }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/generic-service/templates/service-traefik.yaml
+++ b/charts/generic-service/templates/service-traefik.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $value := .Values.frontend }}
-{{- if not $value.loadBalancer.enabled }}
+{{- if or (empty $value.loadBalancer) (not $value.loadBalancer.enabled) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/generic-service/templates/traefikservice.yaml
+++ b/charts/generic-service/templates/traefikservice.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $value := .Values.frontend }}
-{{- if not $value.loadBalancer.enabled }}
+{{- if or (empty $value.loadBalancer) (not $value.loadBalancer.enabled) }}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: TraefikService


### PR DESCRIPTION
The goal of this PR is meant to avoid errors like these:

```
Error: template: generic-service/templates/ingressroute.yaml:15:36: executing "generic-service/templates/ingressroute.yaml" at <$value.host>: wrong type for value; expected string; got interface {}
helm.go:84: [debug] template: generic-service/templates/ingressroute.yaml:15:36: executing "generic-service/templates/ingressroute.yaml" at <$value.host>: wrong type for value; expected string; got interface {}
```

```
Error: template: generic-service/templates/ingressroute.yaml:2:17: executing "generic-service/templates/ingressroute.yaml" at <$value.loadBalancer.enabled>: nil pointer evaluating interface {}.enabled
helm.go:84: [debug] template: generic-service/templates/ingressroute.yaml:2:17: executing "generic-service/templates/ingressroute.yaml" at <$value.loadBalancer.enabled>: nil pointer evaluating interface {}.enabled
```

Helm-charts need to support not having a loadBalancer key at all. 