### PR TITLE
[DEVOPS-2196] Update api version for image update automation

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: generic-service
 description: A Helm chart for Kubernetes
-version: 1.1.4
+version: 1.1.6
 dependencies:
   - name: memcached
     version: 6.6.x

--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: generic-service
 description: A Helm chart for Kubernetes
-version: 1.1.6
+version: 1.1.5
 dependencies:
   - name: memcached
     version: 6.6.x

--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: generic-service
 description: A Helm chart for Kubernetes
-version: 1.1.3
+version: 1.1.4
 dependencies:
   - name: memcached
     version: 6.6.x

--- a/charts/generic-service/templates/imageupdateautomation.yaml
+++ b/charts/generic-service/templates/imageupdateautomation.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
 metadata:
   name: {{ .Release.Name | quote }}
@@ -14,7 +14,7 @@ spec:
         email: tithelybot@users.noreply.github.com
         name: tithelybot
       messageTemplate: |-
-        {{ `{{range .Updated.Images}}{{println .}}{{end}}` }}
+        {{ `{{range .Changed.Images}}{{println .}}{{end}}` }}
     push:
       branch: main
   interval: 1m0s


### PR DESCRIPTION
Easy fix and we’re starting to get warning about deprecations in logs.

https://github.com/fluxcd/image-automation-controller/blob/main/CHANGELOG.md