### PR TITLE
[DEVOPS-2554] Wrap flux image automation in tool conditional 

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: generic-service
 description: A Helm chart for Kubernetes
-version: 1.1.6-alpha
+version: 1.1.6-beta
 dependencies:
   - name: memcached
     version: 6.6.x

--- a/charts/generic-service/templates/imagepolicy.yaml
+++ b/charts/generic-service/templates/imagepolicy.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.tool) (eq .Values.tool "") (eq .Values.tool "flux") }}
 {{- range $key, $value := .Values.worker }}
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
@@ -44,3 +45,4 @@ spec:
       order: asc
   {{- end }}
   {{- end }}
+{{- end -}}

--- a/charts/generic-service/templates/imageupdateautomation.yaml
+++ b/charts/generic-service/templates/imageupdateautomation.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.tool) (eq .Values.tool "") (eq .Values.tool "flux") }}
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
@@ -24,3 +25,4 @@ spec:
   update:
     {{- template "path" . }}
     strategy: Setters
+{{- end }}


### PR DESCRIPTION
This will let us remove flux image automation from those projects using argo while still supporting those that need flux. This does _not_ implement argocd image automation.

Testing:
- Add a root key to the values.yaml called `tool:`. If this has _any_ value other than `null` or `"flux"` then it should _not_ produce imagepolicy and imageupdateautomation resources. 
- Run `helm template test . --values Values.yaml --debug > out.yaml` from the `helm-charts/charts/generic-service` location. 
- Confirm out.yaml is as expected. 