### PR TITLE
[DEVOPS-2997] Implement horizontal pod autoscaler changes

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argocd-app
 description: A Helm chart for applications using ArgoCD
-version: 0.9.1
+version: 1.0.0-alpha

--- a/charts/argocd-apps/Values.yaml
+++ b/charts/argocd-apps/Values.yaml
@@ -1,29 +1,54 @@
-project:
-environment:
+project: 
+environment: 
 onepassworditems:
-  - name:
-    itemPath:
-    secretType:
+- name: 
+  itemPath: 
+  secretType: 
+- name: 
+  itemPath: 
 main:
-  name:
-  enabled:
-  type:
-  image:
-  resources: {}
-  port:
-  replicaCount:
-  loadBalancer:
-    name:
-    targetGroupARN:
-    securityGroupID:
-worker:
-  name:
-  enabled:
-  type:
-  image:
-  command:
-  args:
-    -
-  pullPolicy:
+  name: 
+  enabled: 
+  type: 
+  image: 
   resources:
-  replicaCount:
+    requests:
+      cpu:  # in millicores
+      memory:  # in mebibytes
+    limits:
+      cpu:  # in millicores
+      memory:  # in mebibytes
+  port: 
+  envFrom:
+  - secretRef:
+      name: 
+  loadBalancer:
+    name: 
+    targetGroupARN: 
+    securityGroupID: 
+  autoscaling:
+    enabled: 
+    minReplicaCount: 
+    maxReplicaCount: 
+    cpuUtilizationPercentage: 
+    memoryUtilizationPercentage: 
+worker:
+  name: 
+  enabled: 
+  type: 
+  image: 
+  command: 
+  pullPolicy: 
+  resources:
+    requests:
+      cpu:  # in millicores
+      memory:  # in mebibytes
+    limits:
+      cpu:  # in millicores
+      memory:  # in mebibytes
+  autoscaling:
+    enabled: 
+    minReplicaCount: 
+    maxReplicaCount: 
+    cpuUtilizationPercentage: 
+    memoryUtilizationPercentage: 

--- a/charts/argocd-apps/templates/autoscaler.yaml
+++ b/charts/argocd-apps/templates/autoscaler.yaml
@@ -1,0 +1,53 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.main.name }}-autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.main.name }}
+  minReplicas: {{ .Values.main.autoscaling.minReplicaCount }}
+  maxReplicas: {{ .Values.main.autoscaling.maxReplicaCount }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div .Values.main.resources.limits.cpu .Values.main.resources.requests.cpu | mul .Values.main.autoscaling.cpuUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div .Values.main.resources.limits.memory .Values.main.resources.requests.memory | mul .Values.main.autoscaling.memoryUtilizationPercentage }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.worker.name }}-autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.worker.name }}
+  minReplicas: {{ .Values.worker.autoscaling.minReplicaCount }}
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicaCount }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div .Values.worker.resources.limits.cpu .Values.worker.resources.requests.cpu | mul .Values.worker.autoscaling.cpuUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div .Values.worker.resources.limits.memory .Values.worker.resources.requests.memory | mul .Values.worker.autoscaling.memoryUtilizationPercentage }}

--- a/charts/argocd-apps/templates/autoscaler.yaml
+++ b/charts/argocd-apps/templates/autoscaler.yaml
@@ -9,7 +9,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.main.name }}
-  minReplicas: {{ .Values.main.autoscaling.minReplicaCount }}
+  minReplicas: {{ .Values.main.replicaCount }}
   maxReplicas: {{ .Values.main.autoscaling.maxReplicaCount }}
   metrics:
   - type: Resource
@@ -38,7 +38,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.worker.name }}
-  minReplicas: {{ .Values.worker.autoscaling.minReplicaCount }}
+  minReplicas: {{ .Values.worker.replicaCount }}
   maxReplicas: {{ .Values.worker.autoscaling.maxReplicaCount }}
   metrics:
   - type: Resource

--- a/charts/argocd-apps/templates/autoscaler.yaml
+++ b/charts/argocd-apps/templates/autoscaler.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.main.autoscaling.enabled true }}
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -24,6 +26,8 @@ spec:
         type: Utilization
         # Formula is (limit/request) * desiredPercentage
         averageUtilization: {{ div .Values.main.resources.limits.memory .Values.main.resources.requests.memory | mul .Values.main.autoscaling.memoryUtilizationPercentage }}
+{{- end }}
+{{- if eq .Values.worker.autoscaling.enabled true }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -51,3 +55,4 @@ spec:
         type: Utilization
         # Formula is (limit/request) * desiredPercentage
         averageUtilization: {{ div .Values.worker.resources.limits.memory .Values.worker.resources.requests.memory | mul .Values.worker.autoscaling.memoryUtilizationPercentage }}
+{{- end }}

--- a/charts/argocd-apps/templates/cronjob.yaml
+++ b/charts/argocd-apps/templates/cronjob.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.cronjob }}
 {{- range $key, $value := .Values.cronjob }}
 {{- if eq $value.enabled true }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/argocd-apps/templates/frontend-deployment.yaml
+++ b/charts/argocd-apps/templates/frontend-deployment.yaml
@@ -79,7 +79,12 @@ spec:
               containerPort: {{ .Values.main.port }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.main.resources | nindent 12 }}
+            requests:
+              cpu: "{{ .Values.main.resources.requests.cpu }}m"
+              memory: "{{ .Values.main.resources.requests.memory }}Mi"
+            limits:
+              cpu: "{{ .Values.main.resources.limits.cpu }}m"
+              memory: "{{ .Values.main.resources.limits.memory }}Mi"
           volumeMounts:
             {{- range $key, $value := $.Values.keyinjection }}
             - name: {{ $value.name }}

--- a/charts/argocd-apps/templates/migrations-job.yaml
+++ b/charts/argocd-apps/templates/migrations-job.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.migrations }}
 {{- range $key, $value := .Values.migrations }}
 {{- if eq $value.enabled true }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/argocd-apps/templates/worker-deployment.yaml
+++ b/charts/argocd-apps/templates/worker-deployment.yaml
@@ -57,7 +57,13 @@ spec:
             - name: DD_PROFILING_ENABLED
               value: "true"
           envFrom: {{- toYaml .Values.worker.envFrom | nindent 12 }}
-          resources: {{- toYaml .Values.worker.resources | nindent 12 }}
+          resources:
+            requests:
+              cpu: "{{ .Values.worker.resources.requests.cpu }}m"
+              memory: "{{ .Values.worker.resources.requests.memory }}Mi"
+            limits:
+              cpu: "{{ .Values.worker.resources.limits.cpu }}m"
+              memory: "{{ .Values.worker.resources.limits.memory }}Mi"
           command: {{ .Values.worker.command }}
           args:
           {{- range .Values.worker.args }}

--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: generic-service
 description: A Helm chart for Kubernetes
-version: 1.1.6-delta
+version: 2.0.0-alpha
 dependencies:
   - name: memcached
     version: 6.6.x

--- a/charts/generic-service/templates/autoscaler.yaml
+++ b/charts/generic-service/templates/autoscaler.yaml
@@ -1,0 +1,63 @@
+{{- range $key, $value := .Values.frontend }}
+{{- if eq $value.autoscaling.enabled true }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $value.name }}-autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $value.name }}
+  minReplicas: {{ $value.replicaCount }}
+  maxReplicas: {{ $value.autoscaling.maxReplicaCount }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div $value.resources.limits.cpu $value.resources.requests.cpu | mul $value.autoscaling.cpuUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div $value.resources.limits.memory $value.resources.requests.memory | mul $value.autoscaling.memoryUtilizationPercentage }}
+{{- end }}
+{{- end }}
+
+{{- range $key, $value := .Values.worker }}
+{{- if eq $value.autoscaling.enabled true }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $value.name }}-autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $value.name }}
+  minReplicas: {{ $value.replicaCount }}
+  maxReplicas: {{ $value.autoscaling.maxReplicaCount }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div $value.resources.limits.cpu $value.resources.requests.cpu | mul $value.autoscaling.cpuUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        # Formula is (limit/request) * desiredPercentage
+        averageUtilization: {{ div $value.resources.limits.memory $value.resources.requests.memory | mul $value.autoscaling.memoryUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/charts/generic-service/templates/frontend-deployment.yaml
+++ b/charts/generic-service/templates/frontend-deployment.yaml
@@ -84,7 +84,12 @@ spec:
               containerPort: {{ $value.port }}
               protocol: TCP
           resources:
-            {{- toYaml $value.resources | nindent 12 }}
+            requests:
+              cpu: "{{ $value.resources.requests.cpu }}m"
+              memory: "{{ $value.resources.requests.memory }}Mi"
+            limits:
+              cpu: "{{ $value.resources.limits.cpu }}m"
+              memory: "{{ $value.resources.limits.memory }}Mi"
           volumeMounts:
             {{- range $key, $value := $.Values.keyinjection }}
             - name: {{ $value.name }}

--- a/charts/generic-service/templates/worker-deployment.yaml
+++ b/charts/generic-service/templates/worker-deployment.yaml
@@ -58,7 +58,13 @@ spec:
             - name: DD_PROFILING_ENABLED
               value: "true"
           envFrom: {{- toYaml $value.envFrom | nindent 12 }}
-          resources: {{- toYaml $value.resources | nindent 12 }}
+          resources:
+            requests:
+              cpu: "{{ $value.resources.requests.cpu }}m"
+              memory: "{{ $value.resources.requests.memory }}Mi"
+            limits:
+              cpu: "{{ $value.resources.limits.cpu }}m"
+              memory: "{{ $value.resources.limits.memory }}Mi"
           command: {{ $value.command  }}
           args:
           {{- range $value.args }}


### PR DESCRIPTION
This should enable the Horizontal Pod Autoscaler, allow for multiple crons and migrations, and set limits and request for cpu and memory.

Test with `helm template test . --values Values.yaml --debug > out.yaml` from within `.../charts/argocd`.

Example values yaml in the new Devops-Sandbox 1pass Vault