### PR TITLE
feat(generic-service): add initContainer support to worker deployment

### DIFF
--- a/charts/generic-service/templates/worker-deployment.yaml
+++ b/charts/generic-service/templates/worker-deployment.yaml
@@ -80,6 +80,19 @@ spec:
             - name: {{ $value.name }}
               mountPath: {{ $value.mountPath }}
             {{- end }}
+      {{- if $value.initContainer }}
+      {{- if eq $value.initContainer.enabled true }}
+      initContainers:
+        - name: {{ $value.initContainer.name }}-init
+          image: {{ $value.initContainer.image }}
+          command: {{ $value.initContainer.command }}
+          args:
+          {{- range $value.initContainer.args }}
+            - {{ . }}
+          {{- end }}
+          envFrom: {{- toYaml $value.envFrom | nindent 12 }}
+      {{- end }}
+      {{- end }}
       volumes:
         {{- range $key, $value := $.Values.keyinjection }}
         - name: {{ $value.name }}


### PR DESCRIPTION
## Summary

- Adds `initContainer` support to `worker-deployment.yaml`, matching the identical pattern already in `frontend-deployment.yaml`
- Gated by `$value.initContainer.enabled == true` so it's opt-in and backwards-compatible with all existing worker configs

## Why

The communications-service migration guard (`showmigrations --check`) is being moved from the PHP frontend deployment to the Python worker deployments as PHP is deprecated. This template change is required to support that.

## Test plan

- [ ] Verify a worker with `initContainer.enabled: true` renders the initContainers block in the generated manifest
- [ ] Verify a worker without `initContainer` set renders cleanly with no initContainers block

**Depends on:** devops-cicd PR that moves the migration guard from `frontend-ou` to the four Python workers (`giving-worker`, `messaging-worker`, `communications-worker`, `sites-worker`) — that PR needs this chart version published before the helmrelease version can be bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)